### PR TITLE
Use axios  in the input-field to generate dummy records

### DIFF
--- a/core/core/settings.py
+++ b/core/core/settings.py
@@ -133,6 +133,10 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, 'static'),
+]
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 

--- a/core/home/api/urls.py
+++ b/core/home/api/urls.py
@@ -4,4 +4,5 @@ from . import views
 
 urlpatterns = [
     path('test/', views.generate_student_data_test),
+    path('create_dummy_student_data/', views.generate_student_data), # pass a param ("total") specifying an integer
 ]

--- a/core/home/api/views.py
+++ b/core/home/api/views.py
@@ -1,7 +1,53 @@
 from django.http import JsonResponse
+from home.thread import CreateStudentsThread
+import json
 
 
+# Test API
 def generate_student_data_test(request):
     return JsonResponse({
         'status': 'connected!'
     })
+
+
+
+# API-method [GET] ****************************************************************************************************** [ A P I ]
+"""
+Whenever this api-view/ api-method gets called, it will
+[
+    01. "creating dummy-data-row in the DB".
+    02. "also simultaneously sends that each data to the channel-consumer-group immedietly".
+]
+"""
+async def generate_student_data(request):
+    ### OK, but not using, requires a browser-tab to execute the API-call manually
+    # print(json.loads(request.body))
+
+    # total = request.GET.get('total')    # get the value of "GET" dict-variable ("total") from the browser-url
+    # # since the number is fetchd from the browser-url, it's a string-type number, so it's need to be converted into int.
+    # CreateStudentsThread(int(total)).start()
+    
+    # return JsonResponse({ 
+    #     'trigger': 'To populate data using this page\'s url',
+    #     'status': 200 
+    # })
+    ### OK, but not using, requires a browser-tab to execute the API-call manually
+
+
+    try:
+        if request.method == 'POST':
+            print('Post with Axios!')
+            total_num = request.POST.get('total')
+            json_data = {
+                'total': total_num,
+            }
+            print('Total Number: %s' % total_num)
+            print('Type of: %s' % type(total_num))
+
+            CreateStudentsThread(int(total_num)).start()
+        
+        return JsonResponse({ 'status': True, 
+            'message': 'Success', 
+            'Total_dummy_student_record': json_data })
+    except:
+        return JsonResponse({ 'status': False, 'error': 'Something went wrong' })

--- a/core/home/urls.py
+++ b/core/home/urls.py
@@ -8,7 +8,5 @@ urlpatterns = [
     path('', views.index),
 
     # API-url path
-    path('students/', views.generate_student_data), # pass a param ("total") specifying an integer
-
     path('students/api/', include('home.api.urls')),
 ]

--- a/core/home/views.py
+++ b/core/home/views.py
@@ -3,7 +3,7 @@ from channels.layers import get_channel_layer
 # from asgiref.sync import async_to_sync
 # import json
 # import time
-from .thread import CreateStudentsThread
+
 from .models import *
 
 
@@ -30,23 +30,3 @@ async def index(request):
     return render(request, 'home/index.html')
 
 
-
-# API-method [GET] ****************************************************************************************************** [ A P I ]
-from django.http import JsonResponse
-
-"""
-Whenever this api-view/ api-method gets called, it will
-[
-    "creating dummy-data-row in the DB",
-    "also simultaneously sends that each data to the channel-consumer-group immedietly"
-]
-"""
-async def generate_student_data(request):
-    total = request.GET.get('total')    # get the value of "GET" dict-variable ("total") from the browser-url
-    # since the number is fetchd from the browser-url, it's a string-type number, so it's need to be converted into int.
-    CreateStudentsThread(int(total)).start()
-    
-    return JsonResponse({ 
-        'trigger': 'To populate data using this page\'s url',
-        'status': 200 
-    })

--- a/core/static/js/home/on_submit_handle.js
+++ b/core/static/js/home/on_submit_handle.js
@@ -1,0 +1,35 @@
+// alert('Hellow!')
+
+var input_field = document.getElementById('input_field');
+var submit_btn = document.getElementById('submit_btn');
+
+
+// Input-field enter-btn press
+input_field.onkeypress = function (event) {
+    if (event.keyCode == 13) {
+        axiosPost();
+    }
+}
+
+// Submit btn click
+submit_btn.onclick = function (e) {
+    axiosPost();
+}
+
+// Call the API to start populating Dummy Data
+function axiosPost () {
+    var input_value = input_field.value;
+    var url = 'http://127.0.0.1:8080/students/api/create_dummy_student_data/';
+
+    axios.defaults.xsrfCookieName = 'csrftoken';
+    axios.defaults.xsrfHeaderName = 'X-CSRFToken';
+
+    let data = new FormData();  // easy to pass key-value pair along with the url in 'axios.posy'
+    data.append("total", input_value);
+
+    axios.post(url, data)
+    .then(res => {
+        console.log(res.data);
+    })
+    .catch(errors => console.log(errors))
+}

--- a/core/templates/home/index.html
+++ b/core/templates/home/index.html
@@ -1,4 +1,6 @@
 <!DOCTYPE html>
+{% load static %}
+
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -14,11 +16,28 @@
 
     <div class="container pt-3 mt-5">
     
-        <h1>Home Page</h1>
+        <h1>Home Page: Real-Time Data Population</h1>
 
         <h3>Making this forntend load-process free from the backend's expensive-task (using 'thread' in Django).</h3>
         <p><b> It'll start as soon as possible & since the sever-conections are open by websockets, the asynchronous-consumers continue to send data from the backend.  </b></p>
         <small>To generate bulk-data in the backend, I'm using faker within thread.</small>
+
+        <div class="row mt-5 py-5 bg-light d-flex justify-content-center">
+            <div class="col-6">
+                <div class="input-group">
+                    <span class="input-group-text">Dummy Student Records Number</span>
+                    <input type="number" min="0"
+                        class="form-control text-center" 
+                        aria-label="Put positive-integer numbers only"
+                        placeholder="Enter a positive number"
+                        id="input_field">
+                </div>
+            </div>
+            <div class="col-2">
+                <button type="button" class="btn btn-dark"
+                    id="submit_btn">Generate Data</button>
+            </div>
+        </div>
 
         <p class="mt-5">
             Percent: <b> <span id="progress-completed-text"></span> </b>
@@ -51,6 +70,13 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
 
     <!-- Custom JS -->
+    
+    <!-- Axios CDN -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.21.1/axios.min.js" integrity="sha512-bZS47S7sPOxkjU/4Bt0zrhEtWx0y0CRkhEp8IckzK+ltifIIE9EMIMTuT/mEzoIMewUINruDBIR/jJnbguonqQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <!-- Call thread after clicking the 'generate data' btn (Using Axios) -->
+    <script src="{% static 'js/home/on_submit_handle.js' %}"></script>
+
+    <!-- Websocket Script -->
     <script>
 
         // websocket-url


### PR DESCRIPTION
### Input-field & Axios to Generate Dummy Data

Make the total number of generating dummy-record dynamic using **an input-field** in the home-page
Using **Axios** to post the expecting total-number into the backend-API.

> Thus, now it's not required to use browser-tab-search-field to call the API and total_num to populate the dummy-student-record.